### PR TITLE
Update iron-router-auth.js

### DIFF
--- a/lib/iron-router-auth.js
+++ b/lib/iron-router-auth.js
@@ -19,6 +19,9 @@
                 }
                 
                 options.before = function(){
+                    if(Meteor.loggingIn())
+                        return stop();
+                        
                     if(options.redirectOnLogin && Meteor.user()){
                         if(Session.get(redirectKey)){
                             var rname = Session.get(redirectKey);


### PR DESCRIPTION
This fixes issues with the latest Meteor (7.1.2) and Iron-Router (6.1) builds. Otherwise reloading a page triggers the before too early, making Meteor.user() return 'undefined' in the before hook.
