### PR TITLE
Provide the option to make the logged-in test more nuanced than just (!Meteor.user())

### DIFF
--- a/lib/iron-router-auth.js
+++ b/lib/iron-router-auth.js
@@ -5,6 +5,13 @@
     _.extend(Router, {
        _route: Router.route,
         route: function(name, options){
+            function isLoggedIn() {
+                if(Router.options.isLoggedIn !== undefined)
+                    return Router.options.isLoggedIn();
+                else
+                    return (Meteor.user() !== null);
+            }
+
             if(options.redirectOnLogin && Session.get(redirectKey)){
                 var rname = Session.get(redirectKey);
                 Session.set(redirectKey, null);
@@ -45,7 +52,7 @@
                             options.loginRequired.shouldRoute = true;
                         }
 
-                        if(!Meteor.user()){
+                        if(!isLoggedIn()){
                             Session.set(redirectKey, Router.current().path);
 
                             if(options.loginRequired.shouldRoute){


### PR DESCRIPTION
This patch supports a function to override the default behavior of determining if the user is logged in by calling !Meteor.user(). I'm using it for leveraging iron-router-auth's routing to reroute users who do not have  a verified email address.
